### PR TITLE
fix(security): recognised sanitizer for js/log-injection (follow-up to #1398)

### DIFF
--- a/examples/voice/static/plain/index.html
+++ b/examples/voice/static/plain/index.html
@@ -494,12 +494,10 @@
           .with({ kind: 'voice-incoming-end' }, (m) => endIncoming(m.from))
           .with({ kind: 'system' }, () => { /* informational */ })
           .otherwise(() => {
-            // Log only the sanitized `kind` tag, never the raw server payload,
-            // so a crafted message can't forge console entries (CodeQL
-            // js/log-injection).
-            const kind =
-              typeof m?.kind === 'string' ? m.kind.replace(/[^\w.:-]/g, '') : '(unknown)';
-            console.debug('unhandled server msg kind:', kind);
+            // Encode the user-controlled value before logging so a crafted
+            // message can't forge console entries. encodeURIComponent is a
+            // sanitizer CodeQL recognises for js/log-injection.
+            console.debug('unhandled server msg kind:', encodeURIComponent(String(m?.kind ?? '')));
           });
       }
 


### PR DESCRIPTION
Follow-up to #1398.

After #1398 merged, CodeQL's develop scan closed alerts 10/11/15 but opened a **new** `js/log-injection` alert (#16) on `examples/voice/static/plain/index.html`: the sanitizer used there (`String.replace(/[^\w.:-]/g, '')`) strips newlines but is not a form CodeQL models as a sanitizer, so the tainted `kind` still flowed into `console.debug`.

This switches to `encodeURIComponent(String(m?.kind ?? ''))`, which CodeQL recognises as a log-injection sanitizer — clearing #16 while keeping the value safe to log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
